### PR TITLE
pome76: remove game combos

### DIFF
--- a/config/boards/shields/pome76-u/pome76-u.keymap
+++ b/config/boards/shields/pome76-u/pome76-u.keymap
@@ -193,17 +193,7 @@
             key-positions = <16 17 18>;
             bindings = <&sl SYS>;
         };
-        combo_standard {
-            timeout-ms = <FAST_COMBO_TIMEOUT>;
-            key-positions = <31 32 33>;
-            bindings = <&to WIN>;
-        };
-        combo_game {
-            timeout-ms = <FAST_COMBO_TIMEOUT>;
-            key-positions = <46 47 48>;
-            bindings = <&to GAM>;
-        };
-
+        
         // Slow combos: these combos exclusively use keys controlled by a single index-finger,
         // which makes them very unlikely to be accidentally triggered by a standard touch-typist
         // them during normal typing, even with a very long timeout.


### PR DESCRIPTION
Somehow, removing these two combos fixed an issue where `d_down + s_down` (within fast_combo_timeout) would not send LSFT_down until s_up or otherKey_down. This prevented `d_down + s_down + mouse_down` from producing a shifted click as desired.