### PR TITLE
Pome76: space combos, relocate lbkt rbkt bslh

### DIFF
--- a/config/boards/shields/pome76-u/pome76-u.keymap
+++ b/config/boards/shields/pome76-u/pome76-u.keymap
@@ -218,20 +218,20 @@
         };
 
         // Space combos
-        combo_lbkt {
+        combo_blsh {
             timeout-ms = <SPACE_COMBO_TIMEOUT>;
             key-positions = <28 71>; /* I Space */
+            bindings = <&kp BSLH>;
+        };
+        combo_lbkt {
+            timeout-ms = <SPACE_COMBO_TIMEOUT>;
+            key-positions = <29 71>; /* O Space */
             bindings = <&kp LBKT>;
         };
         combo_rbkt {
             timeout-ms = <SPACE_COMBO_TIMEOUT>;
-            key-positions = <29 71>; /* O Space */
-            bindings = <&kp RBKT>;
-        };
-        combo_blsh {
-            timeout-ms = <SPACE_COMBO_TIMEOUT>;
             key-positions = <30 71>; /* P Space */
-            bindings = <&kp BSLH>;
+            bindings = <&kp RBKT>;
         };
         combo_quot {
             timeout-ms = <SPACE_COMBO_TIMEOUT>;


### PR DESCRIPTION
relocate lbkt and rbkt to align with (). This necessitates moving bslh as well