### PR TITLE
Pome76 replace numbers layer with symbols layer

### DIFF
--- a/config/boards/shields/pome76-u/pome76-u.keymap
+++ b/config/boards/shields/pome76-u/pome76-u.keymap
@@ -209,7 +209,7 @@
             hold-trigger-key-positions = <48 49 63 64 65 66 72 73>;
         };
 
-        wlt: windows_mod_tap {
+        wmt: windows_mod_tap {
             compatible = "zmk,behavior-hold-tap";
             label = "WINDOWS_MOD_TAP";
             #binding-cells = <2>;
@@ -276,7 +276,7 @@
 &kp Q         &kp W         &kp E         &kp R         &kp T         &kp N7        &kp N8        &kp N9        &kp KP_PLUS   &kp RBKT      &kp Y         &kp U         &kp I         &kp O         &kp P
 &kp A         &smt S S      &dlt DL D     &fmt F F      &kp G         &kp N4        &kp N5        &kp N6        &kp BKSP      &kp LBKT      &kp H         &kp J         &klt KL K     &lmt L L      &kp SCLN
 &kp LSFT      &kp Z         &xmt X X      &clt CL C     &vmt V V      &kp B         &kp N1        &kp N2        &kp N3        &kp DEL       &kp BSLH      &kp N         &kp M         &kp CMMA      &kp DOT
-&kp ESC       &kp DEL       &kp SPC       &kp LGUI      &kp LCTL      &kp LALT      &kp SPC       &kp N0        &kp DOT       &wlt RGUI RET &kp SPC       &mo NAV       &mo MED       &kp BKSP      &kp RET
+&kp ESC       &kp DEL       &kp SPC       &kp LGUI      &kp LCTL      &kp LALT      &kp SPC       &kp N0        &kp DOT       &wmt RGUI RET &kp SPC       &mo NAV       &mo MED       &kp BKSP      &kp RET
             >;
         };
         

--- a/config/boards/shields/pome76-u/pome76-u.keymap
+++ b/config/boards/shields/pome76-u/pome76-u.keymap
@@ -208,15 +208,6 @@
             bindings = <&mcv>, <&kp>;
             hold-trigger-key-positions = <48 49 63 64 65 66 72 73>;
         };
-
-        wmt: windows_mod_tap {
-            compatible = "zmk,behavior-hold-tap";
-            label = "WINDOWS_MOD_TAP";
-            #binding-cells = <2>;
-            flavor = "tap-unless-interrupted";
-            tapping-term-ms = <1000>; // 200 was a little too short as I am learning the keymap. Increasing to 1000.
-            bindings = <&kp>, <&kp>;
-        };
     };
 
     sl {
@@ -265,6 +256,11 @@
             key-positions = <14 15>; /* 0 Bksp */
             bindings = <&kp CAPS>;
         };
+        combo_media_layer {
+            timeout-ms = <SLOW_TIMEOUT>;
+            key-positions = <71 72>; /* Space NavLayer */
+            bindings = <&mo MED>;
+        };
     };
 
     keymap {
@@ -276,7 +272,7 @@
 &kp Q         &kp W         &kp E         &kp R         &kp T         &kp N7        &kp N8        &kp N9        &kp KP_PLUS   &kp RBKT      &kp Y         &kp U         &kp I         &kp O         &kp P
 &kp A         &smt S S      &dlt DL D     &fmt F F      &kp G         &kp N4        &kp N5        &kp N6        &kp BKSP      &kp LBKT      &kp H         &kp J         &klt KL K     &lmt L L      &kp SCLN
 &kp LSFT      &kp Z         &xmt X X      &clt CL C     &vmt V V      &kp B         &kp N1        &kp N2        &kp N3        &kp DEL       &kp BSLH      &kp N         &kp M         &kp CMMA      &kp DOT
-&kp ESC       &kp DEL       &kp SPC       &kp LGUI      &kp LCTL      &kp LALT      &kp SPC       &kp N0        &kp DOT       &wmt RGUI RET &kp SPC       &mo NAV       &mo MED       &kp BKSP      &kp RET
+&kp ESC       &kp DEL       &kp SPC       &kp LGUI      &kp LCTL      &kp LALT      &kp SPC       &kp N0        &kp DOT       &kp RET       &kp SPC       &mo NAV       &kp RGUI      &kp BKSP      &kp RET
             >;
         };
         

--- a/config/boards/shields/pome76-u/pome76-u.keymap
+++ b/config/boards/shields/pome76-u/pome76-u.keymap
@@ -32,7 +32,8 @@
 // [1Jan2024] Initialize 100 ms. Arbitarily chosen somewhere between FAST_TIMEOUT (35 ms) and SLOW_TIMEOUT (200 ms).
 // [1Jan2024] 100 => 75 ms because ,. => FSLH is unintentionally being triggered when I attempt to type "<>".
 // [1Jan2024] 75 => 50 ms because typing "<>" quickly still triggers FSLH too eagerly.
-#define MEDIUM_TIMEOUT 50
+// [3Feb2024] 50 => 67 ms because I am missing " (L+;) too frequently.
+#define MEDIUM_TIMEOUT 67
 
 // SLOW_TIMEOUT is very long.
 // It is mostly used for combos involving keys that are controlled by the same finger, and should therefore by typed relatively slowly and in strict sequence.

--- a/config/boards/shields/pome76-u/pome76-u.keymap
+++ b/config/boards/shields/pome76-u/pome76-u.keymap
@@ -299,7 +299,7 @@
             bindings = <
 &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
 &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
-&trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &kp BSLH      &kp LBKT      &kp RBKT      &trans
+&trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
 &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
 &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
             >;
@@ -308,7 +308,7 @@
         num_layer {
             bindings = <
 &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
-&trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
+&trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &kp BSLH      &kp LBKT      &kp RBKT      &trans
 &trans        &kp LSFT      &mo DL        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &kp GRAV      &kp MINUS     &kp EQL       &trans
 &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
 &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans

--- a/config/boards/shields/pome76-u/pome76-u.keymap
+++ b/config/boards/shields/pome76-u/pome76-u.keymap
@@ -273,7 +273,7 @@
 &kp Q         &kp W         &kp E         &kp R         &kp T         &kp N7        &kp N8        &kp N9        &kp KP_PLUS   &kp RBKT      &kp Y         &kp U         &kp I         &kp O         &kp P
 &kp A         &smt S S      &dlt DL D     &fmt F F      &kp G         &kp N4        &kp N5        &kp N6        &kp BKSP      &kp LBKT      &kp H         &kp J         &klt KL K     &lmt L L      &kp SCLN
 &kp LSFT      &kp Z         &xmt X X      &clt CL C     &vmt V V      &kp B         &kp N1        &kp N2        &kp N3        &kp DEL       &kp BSLH      &kp N         &kp M         &kp CMMA      &kp DOT
-&kp ESC       &kp DEL       &kp SPC       &kp LGUI      &kp LCTL      &kp LALT      &kp SPC       &kp N0        &kp DOT       &kp RET       &kp SPC       &mo NAV       &kp RGUI      &kp BKSP      &kp RET
+&kp ESC       &kp DEL       &kp SPC       &kp LGUI      &kp LCTL      &kp LALT      &kp SPC       &kp N0        &kp DOT       &kp RET       &kp SPC       &mo NAV       &kp RGUI      &kp DEL       &kp RET
             >;
         };
         

--- a/config/boards/shields/pome76-u/pome76-u.keymap
+++ b/config/boards/shields/pome76-u/pome76-u.keymap
@@ -257,10 +257,10 @@
             key-positions = <14 15>; /* 0 Bksp */
             bindings = <&kp CAPS>;
         };
-        combo_media_layer {
+        combo_rgui {
             timeout-ms = <SLOW_TIMEOUT>;
             key-positions = <71 72>; /* Space NavLayer */
-            bindings = <&mo MED>;
+            bindings = <&kp RGUI>;
         };
     };
 
@@ -273,7 +273,7 @@
 &kp Q         &kp W         &kp E         &kp R         &kp T         &kp N7        &kp N8        &kp N9        &kp KP_PLUS   &kp RBKT      &kp Y         &kp U         &kp I         &kp O         &kp P
 &kp A         &smt S S      &dlt DL D     &fmt F F      &kp G         &kp N4        &kp N5        &kp N6        &kp BKSP      &kp LBKT      &kp H         &kp J         &klt KL K     &lmt L L      &kp SCLN
 &kp LSFT      &kp Z         &xmt X X      &clt CL C     &vmt V V      &kp B         &kp N1        &kp N2        &kp N3        &kp DEL       &kp BSLH      &kp N         &kp M         &kp CMMA      &kp DOT
-&kp ESC       &kp DEL       &kp SPC       &kp LGUI      &kp LCTL      &kp LALT      &kp SPC       &kp N0        &kp DOT       &kp RET       &kp SPC       &mo NAV       &kp RGUI      &kp DEL       &kp RET
+&kp ESC       &kp DEL       &kp SPC       &kp LGUI      &kp LCTL      &kp LALT      &kp SPC       &kp N0        &kp DOT       &kp RET       &kp SPC       &mo NAV       &mo MED       &kp DEL       &kp RET
             >;
         };
         

--- a/config/boards/shields/pome76-u/pome76-u.keymap
+++ b/config/boards/shields/pome76-u/pome76-u.keymap
@@ -113,10 +113,10 @@
 
     // Position documentation.
     // 63, 64, 65, and 66 are left hand modifier keys
-    // 72 and 73 and right hand layer keys
+    // 72 and 73 and right hand layer keys (nav and media layers)
     // 32 is S
     // 43 is K
-    // 46 is the start of the Z row
+    // 56 is the start of the Z row
 
     behaviors {
         // F-key: hold = flash, tap = F
@@ -265,6 +265,11 @@
             key-positions = <14 15>; /* 0 Bksp */
             bindings = <&kp CAPS>;
         };
+        combo_rgui {
+            timeout-ms = <SLOW_TIMEOUT>;
+            key-positions = <71 72>; /* Space NavLayer */
+            bindings = <&kp RGUI>;
+        };
     };
 
     keymap {
@@ -303,10 +308,10 @@
         num_layer {
             bindings = <
 &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
-&trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &kp GRAV      &kp N7        &kp N8        &kp N9        &kp N0
-&trans        &kp LSFT      &mo DL        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &kp EQL       &kp N4        &kp N5        &kp N6        &kp DOT
-&trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &kp MINUS     &kp N1        &kp N2        &kp N3
-&trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &kp SPC       &mo NAV       &mo MED       &trans        &trans
+&trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
+&trans        &kp LSFT      &mo DL        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &kp GRAV      &kp MINUS     &kp EQL       &trans
+&trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
+&trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
             >;
         };
 

--- a/config/boards/shields/pome76-u/pome76-u.keymap
+++ b/config/boards/shields/pome76-u/pome76-u.keymap
@@ -301,7 +301,7 @@
             bindings = <
 &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
 &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &kp BSLH      &kp LBKT      &kp RBKT      &trans
-&trans        &kp LSFT      &mo DL        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &kp GRAV      &kp MINUS     &kp EQL       &trans
+&trans        &kp LSFT      &mo DL        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &kp MINUS     &kp EQL       &kp GRAV      &trans
 &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
 &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans        &trans
             >;

--- a/config/boards/shields/pome76-u/pome76-u.keymap
+++ b/config/boards/shields/pome76-u/pome76-u.keymap
@@ -209,13 +209,13 @@
             hold-trigger-key-positions = <48 49 63 64 65 66 72 73>;
         };
 
-        sylt: symbols_layer_tap {
+        wlt: windows_mod_tap {
             compatible = "zmk,behavior-hold-tap";
-            label = "SYMBOLS_LAYER_TAP";
+            label = "WINDOWS_MOD_TAP";
             #binding-cells = <2>;
             flavor = "tap-unless-interrupted";
             tapping-term-ms = <1000>; // 200 was a little too short as I am learning the keymap. Increasing to 1000.
-            bindings = <&mo>, <&kp>;
+            bindings = <&kp>, <&kp>;
         };
     };
 
@@ -265,11 +265,6 @@
             key-positions = <14 15>; /* 0 Bksp */
             bindings = <&kp CAPS>;
         };
-        combo_rgui {
-            timeout-ms = <SLOW_TIMEOUT>;
-            key-positions = <71 72>; /* Space NavLayer */
-            bindings = <&kp RGUI>;
-        };
     };
 
     keymap {
@@ -281,7 +276,7 @@
 &kp Q         &kp W         &kp E         &kp R         &kp T         &kp N7        &kp N8        &kp N9        &kp KP_PLUS   &kp RBKT      &kp Y         &kp U         &kp I         &kp O         &kp P
 &kp A         &smt S S      &dlt DL D     &fmt F F      &kp G         &kp N4        &kp N5        &kp N6        &kp BKSP      &kp LBKT      &kp H         &kp J         &klt KL K     &lmt L L      &kp SCLN
 &kp LSFT      &kp Z         &xmt X X      &clt CL C     &vmt V V      &kp B         &kp N1        &kp N2        &kp N3        &kp DEL       &kp BSLH      &kp N         &kp M         &kp CMMA      &kp DOT
-&kp ESC       &kp DEL       &kp SPC       &kp LGUI      &kp LCTL      &kp LALT      &kp SPC       &kp N0        &kp DOT       &sylt SYL RET &kp SPC       &mo NAV       &mo MED       &kp BKSP      &kp RET
+&kp ESC       &kp DEL       &kp SPC       &kp LGUI      &kp LCTL      &kp LALT      &kp SPC       &kp N0        &kp DOT       &wlt RGUI RET &kp SPC       &mo NAV       &mo MED       &kp BKSP      &kp RET
             >;
         };
         


### PR DESCRIPTION
replace numbers layer with symbols layer, because redundant key options makes fluency really hard.
add a way for the right hand to trigger win key, so that it is possible to win+6 without relying a left-hand-only contortion