### PR TITLE
pome76: move sys combo to lower right hand corner

### DIFF
--- a/config/boards/shields/pome76-u/pome76-u.keymap
+++ b/config/boards/shields/pome76-u/pome76-u.keymap
@@ -217,7 +217,7 @@
 
         combo_sys {
             timeout-ms = <SLOW_TIMEOUT>;
-            key-positions = <0 1 2>; /* 1 2 3 */
+            key-positions = <73 74 75>; /* lower right hand corner */
             bindings = <&sl SYS>;
         };
         combo_tab {


### PR DESCRIPTION
It is sometimes useful to type 123 very quickly, leading to accidental sys combo trigger. Moving to the lower right hand corner to avoid this